### PR TITLE
DNSSEC support enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ Changelog
 
 :construction: Work in Progress - [see issue #1](https://github.com/mr-bolle/docker-openvpn-pihole/issues/1)
 
+0.7 2019.02.17
+- openvpn-install.sh
+  - set "DNSSEC=true" to pihole/setupVars.conf
+  - set "API_QUERY_LOG_SHOW=blockedonly" to pihole/setupVars.conf
+
+- docker-compose.yml
+  - change DNS1=46.182.19.48 Digitalcourage and DNS2=213.73.91.35 Chaos Computer Club (this DNS support DNS)
+
 0.6 2019.02.11
 - fix pihole resolv.conf [#410](https://github.com/pi-hole/docker-pi-hole/issues/410)
 - fix pihole dns environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changelog
   - set "API_QUERY_LOG_SHOW=blockedonly" to pihole/setupVars.conf
 
 - docker-compose.yml
-  - change DNS1=46.182.19.48 Digitalcourage and DNS2=213.73.91.35 Chaos Computer Club (this DNS support DNS)
+  - change DNS1=46.182.19.48 Digitalcourage and DNS2=213.73.91.35 Chaos Computer Club (this support DNSSecure check this with [DNSSEC Resolver Test](http://dnssec.vs.uni-due.de/))
 
 0.6 2019.02.11
 - fix pihole resolv.conf [#410](https://github.com/pi-hole/docker-pi-hole/issues/410)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,9 +51,9 @@ services:
      environment:
        WEBPASSWORD: fcvFjLIO2hWhkFCi
        ServerIP: 0.0.0.0
-       DNS1: 208.67.222.222
-       DNS2: 1.0.0.1
-       API_QUERY_LOG_SHOW: blockedonly        # pihole/setupVars.conf
+# #1 Digitalcourage | #2 Chaos Computer Club
+       DNS1: 46.182.19.48
+       DNS2: 213.73.91.35
      volumes:
        - ./pihole:/etc/pihole
        - ./pihole_dnsmasq.d:/etc/dnsmasq.d

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -189,5 +189,9 @@ echo -e "   ____________________________________________________________________
 docker network inspect vpn-net &>/dev/null || 
     docker network create --driver=bridge --subnet=172.110.1.0/24 --gateway=172.110.1.1 vpn-net
 
+# set DNSSEC=true to pihole/setupVars.conf 
+mkdir -p pihole && echo "DNSSEC=true" >> pihole/setupVars.conf
+echo "API_QUERY_LOG_SHOW=blockedonly" >> pihole/setupVars.conf
+
 # run docker-compose
 docker-compose up -d


### PR DESCRIPTION
0.7 2019.02.17
- openvpn-install.sh
  - set "DNSSEC=true" to pihole/setupVars.conf
  - set "API_QUERY_LOG_SHOW=blockedonly" to pihole/setupVars.conf

- docker-compose.yml
  - change DNS1=46.182.19.48 Digitalcourage and DNS2=213.73.91.35 Chaos Computer Club (this support DNSSecure check this with [DNSSEC Resolver Test](http://dnssec.vs.uni-due.de/))

0.6 2019.02.11
- fix pihole resolv.conf [#410](https://github.com/pi-hole/docker-pi-hole/issues/410)
- fix pihole dns environment